### PR TITLE
Added admin page toggle switch and setup "add" pages

### DIFF
--- a/client/src/admin/add-judges.tsx
+++ b/client/src/admin/add-judges.tsx
@@ -1,0 +1,9 @@
+const AddJudges = () => {
+    return (
+        <div>
+            <h1>Add Judges</h1>
+        </div>
+    );
+};
+
+export default AddJudges;

--- a/client/src/admin/add-projects.tsx
+++ b/client/src/admin/add-projects.tsx
@@ -1,0 +1,9 @@
+const AddProjects = () => {
+    return (
+        <div>
+            <h1>Add Projects</h1>
+        </div>
+    );
+};
+
+export default AddProjects;

--- a/client/src/admin/index.tsx
+++ b/client/src/admin/index.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import AdminStatsPanel from '../components/admin/AdminStatsPanel';
+import AdminTable from '../components/admin/AdminTable';
 import AdminToggleSwitch from '../components/admin/AdminToggleSwitch';
+import AdminToolbar from '../components/admin/AdminToolbar';
 import JuryHeader from '../components/JuryHeader';
 
 const Admin = () => {
@@ -10,6 +12,8 @@ const Admin = () => {
             <JuryHeader withLogout isAdmin />
             <AdminStatsPanel />
             <AdminToggleSwitch state={showProjects} setState={setShowProjects} />
+            <AdminToolbar showProjects={showProjects} />
+            <AdminTable showProjects={showProjects} />
         </>
     );
 };

--- a/client/src/admin/index.tsx
+++ b/client/src/admin/index.tsx
@@ -1,11 +1,15 @@
+import { useState } from 'react';
 import AdminStatsPanel from '../components/admin/AdminStatsPanel';
+import AdminToggleSwitch from '../components/admin/AdminToggleSwitch';
 import JuryHeader from '../components/JuryHeader';
 
 const Admin = () => {
+    const [showProjects, setShowProjects] = useState(false);
     return (
         <>
             <JuryHeader withLogout isAdmin />
             <AdminStatsPanel />
+            <AdminToggleSwitch state={showProjects} setState={setShowProjects} />
         </>
     );
 };

--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { twMerge } from 'tailwind-merge';
 
 interface ButtonProps {
     /* Button internal content */
@@ -31,13 +32,14 @@ interface ButtonProps {
 const Button = (props: ButtonProps) => {
     // Define formatting
     const defaultFormat =
-        'rounded-full py-4 w-3/4 text-center text-2xl no-underline outline-none border-none md:w-2/3 ';
+        'py-4 w-3/4 text-center text-2xl no-underline outline-none border-none md:w-2/3 ';
     const typeFormat =
         props.type === 'primary' ? 'bg-primary text-background' : 'bg-transparent text-primary';
+    const squareFormat = props.square ? 'rounded-lg' : 'rounded-full';
     const varFormat = !props.disabled
         ? typeFormat + ' cursor-pointer duration-200 hover:scale-110 focus:scale-110'
         : 'cursor-auto text-lighter bg-backgroundDark';
-    const formatting = defaultFormat + ' ' + varFormat;
+    const formatting = twMerge(defaultFormat, varFormat, squareFormat, props.className);
 
     // Disable button bc links cannot be disabled
     return props.disabled ? (

--- a/client/src/components/admin/AdminTable.tsx
+++ b/client/src/components/admin/AdminTable.tsx
@@ -1,0 +1,5 @@
+const AdminTable = (props: { showProjects: boolean }) => {
+    return <div></div>;
+};
+
+export default AdminTable;

--- a/client/src/components/admin/AdminToggleSwitch.tsx
+++ b/client/src/components/admin/AdminToggleSwitch.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { twMerge } from 'tailwind-merge';
+
+const AdminToggleSwitch = (props: {
+    state: boolean;
+    setState: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
+    return (
+        <div className="w-full flex flex-row items-center justify-center my-10">
+            <button
+                className={twMerge("block px-4 py-2 text-3xl rounded-full", props.state ? "bg-primary text-white" : "bg-backgroundDark")}
+                onClick={() => {
+                    props.setState(true);
+                }}
+            >
+                Projects
+            </button>
+            <button
+                className={twMerge("block px-4 py-2 text-3xl rounded-full", !props.state ? "bg-primary text-white" : "bg-backgroundDark")}
+                onClick={() => {
+                    props.setState(false);
+                }}
+            >
+                Judges
+            </button>
+        </div>
+    );
+};
+
+export default AdminToggleSwitch;

--- a/client/src/components/admin/AdminToolbar.tsx
+++ b/client/src/components/admin/AdminToolbar.tsx
@@ -1,0 +1,5 @@
+const AdminToolbar = (props: { showProjects: boolean }) => {
+    return <div></div>;
+};
+
+export default AdminToolbar;

--- a/client/src/components/admin/AdminToolbar.tsx
+++ b/client/src/components/admin/AdminToolbar.tsx
@@ -1,5 +1,20 @@
+import Button from '../Button';
+
 const AdminToolbar = (props: { showProjects: boolean }) => {
-    return <div></div>;
+    return (
+        <div className="flex flex-row px-8">
+            <div>
+                <Button
+                    type="primary"
+                    square
+                    className="py-2 px-4"
+                    href={props.showProjects ? '/admin/add-projects' : '/admin/add-judges'}
+                >
+                    Add {props.showProjects ? 'Projects' : 'Judges'}
+                </Button>
+            </div>
+        </div>
+    );
 };
 
 export default AdminToolbar;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -8,6 +8,8 @@ import JudgeLogin from './judge/login';
 import Judge from './judge';
 import AdminLogin from './admin/login';
 import Admin from './admin';
+import AddProjects from './admin/add-projects';
+import AddJudges from './admin/add-judges';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
@@ -31,6 +33,14 @@ const router = createBrowserRouter([
     {
         path: '/admin',
         element: <Admin />,
+    },
+    {
+        path: '/admin/add-projects',
+        element: <AddProjects />,
+    },
+    {
+        path: '/admin/add-judges',
+        element: <AddJudges />,
     },
 ]);
 


### PR DESCRIPTION
### Description

* Added basic toggle switch (v. ugly!) to switch between projects/judges views
* Added pages for add judges and add projects (empty rn!)

### Type of Change

Delete options that do not apply:

- New feature (non-breaking change which adds functionality)

### Is this a breaking change?

- [ ] Yes
- [X] No
