### PR TITLE
feat: autofill code if present

### DIFF
--- a/client/src/components/PasswordInput.tsx
+++ b/client/src/components/PasswordInput.tsx
@@ -47,6 +47,7 @@ const PasswordInput = (props: PasswordInputProps) => {
     return (
         <>
             <input
+                value={props.value}
                 type={props.isHidden ? 'password' : 'text'}
                 maxLength={props.maxLength}
                 id="text-input"
@@ -73,7 +74,7 @@ const PasswordInput = (props: PasswordInputProps) => {
                     props.error ? 'text-error' : focused ? 'text-primary' : ''
                 )}
             >
-                {props.error ? (props.errorMessage || props.label) : props.label}
+                {props.error ? props.errorMessage || props.label : props.label}
             </label>
         </>
     );

--- a/client/src/judge/login.tsx
+++ b/client/src/judge/login.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import Cookies from 'universal-cookie';
 import Button from '../components/Button';
 import Container from '../components/Container';
@@ -8,6 +8,9 @@ import PasswordInput from '../components/PasswordInput';
 import Loading from '../components/Loading';
 
 const JudgeLogin = () => {
+    const [searchParams] = useSearchParams();
+    const [codeParam] = useState(searchParams.get('code') || '');
+
     const [disabled, setDisabled] = useState(true);
     const [code, setCode] = useState('');
     const [loginLock, setLoginLock] = useState(false);
@@ -16,6 +19,9 @@ const JudgeLogin = () => {
 
     // If token cookie is already defined and valid, redirect to judge page
     useEffect(() => {
+        if (codeParam.length === 6) {
+            setCode(codeParam);
+        }
         async function checkCookies() {
             const cookies = new Cookies();
 
@@ -114,6 +120,7 @@ const JudgeLogin = () => {
             <JuryHeader />
             <Container>
                 <PasswordInput
+                    value={code}
                     label="Enter your judging code"
                     maxLength={6}
                     placeholder="000000"


### PR DESCRIPTION
### Description

Autofill Judging Code if present in the url search params 
will only fill its 6 characters

### Fixes #10

### Type of Change

Delete options that do not apply:

- New feature (non-breaking change which adds functionality)


### Is this a breaking change?

- [ ] Yes
- [X ] No
